### PR TITLE
ci(actions): restrict test workflow permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
Adds an explicit minimal permissions block to the test workflow so the default GITHUB_TOKEN is limited to read-only repository contents.

## Context
GitHub code scanning reported alert #4, actions/missing-workflow-permissions, in .github/workflows/run-tests.yml. The workflow only needs repository read access for checkout and test execution.

## Validation
- actionlint .github/workflows/run-tests.yml
- composer test