### PR TITLE
fix(package): honor commentable model configuration (#21)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "test:refactor": "rector --dry-run",
         "test:types": "phpstan",
         "test:type-coverage": "pest --type-coverage --min=100 --compact",
-        "test:coverage": "pest --parallel --coverage --compact --exactly=68.8",
+        "test:coverage": "pest --parallel --coverage --compact --exactly=68.7",
         "test:typos": "peck",
         "test": [
             "@test:lint",

--- a/database/migrations/create_commentable_table.php
+++ b/database/migrations/create_commentable_table.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create(config('commentable.comment_table', 'comments'), function (Blueprint $table): void {
@@ -35,12 +32,9 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
-        Schema::dropIfExists(config('commentable.tables.reactions', 'reactions'));
-        Schema::dropIfExists(config('commentable.tables.comments', 'comments'));
+        Schema::dropIfExists(config('commentable.reaction_table', 'reactions'));
+        Schema::dropIfExists(config('commentable.comment_table', 'comments'));
     }
 };

--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -65,7 +65,7 @@ return [
 ];
 ```
 
-**Use case:** Extend the default models with your own implementations.
+**Use case:** Extend the package base models with your own implementations. Custom comment models must extend `Akira\Commentable\Models\Message`; custom reaction models must extend `Akira\Commentable\Models\BaseReaction`.
 
 **Example:**
 
@@ -76,9 +76,9 @@ Create your custom Comment model:
 
 namespace App\Models;
 
-use Akira\Commentable\Models\Comment as BaseComment;
+use Akira\Commentable\Models\Message;
 
-class Comment extends BaseComment
+class Comment extends Message
 {
     protected $appends = ['is_edited', 'excerpt'];
 
@@ -94,27 +94,40 @@ class Comment extends BaseComment
 }
 ```
 
+Create your custom Reaction model:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Akira\Commentable\Models\BaseReaction;
+
+class Reaction extends BaseReaction
+{
+    protected $appends = ['label'];
+
+    public function getLabelAttribute(): string
+    {
+        return str($this->type)->headline();
+    }
+}
+```
+
 Update the configuration:
 
 ```php
 'models' => [
     'comment' => \App\Models\Comment::class,
-    'reaction' => \Akira\Commentable\Models\Reaction::class,
+    'reaction' => \App\Models\Reaction::class,
 ],
 ```
 
-Update the `Commentable` trait usage to reference your custom model in the relationship:
+The package relationships read these configured classes when creating comments and loading reactions:
 
 ```php
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-
-trait Commentable
-{
-    public function comments(): MorphMany
-    {
-        return $this->morphMany(config('commentable.models.comment'), 'commentable');
-    }
-}
+$post->comments()->create([...]);     // App\Models\Comment
+$comment->reactions()->create([...]); // App\Models\Reaction
 ```
 
 ## Complete Configuration File

--- a/docs/06-database-schema.md
+++ b/docs/06-database-schema.md
@@ -227,6 +227,13 @@ Schema::create(config('commentable.reaction_table', 'reactions'), function (Blue
 });
 ```
 
+Rollback uses the same configured table names:
+
+```php
+Schema::dropIfExists(config('commentable.reaction_table', 'reactions'));
+Schema::dropIfExists(config('commentable.comment_table', 'comments'));
+```
+
 ---
 
 ## Query Examples

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -53,21 +53,3 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: src/Models/Message.php
-
-		-
-			message: '#^Parameter \#1 \$related of method Illuminate\\Database\\Eloquent\\Model\:\:belongsTo\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Model\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Models/Reaction.php
-
-		-
-			message: '#^Parameter \#2 \$foreignKey of method Illuminate\\Database\\Eloquent\\Model\:\:belongsTo\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Models/Reaction.php
-
-		-
-			message: '#^Unable to resolve the template type TRelatedModel in call to method Illuminate\\Database\\Eloquent\\Model\:\:belongsTo\(\)$#'
-			identifier: argument.templateType
-			count: 1
-			path: src/Models/Reaction.php

--- a/src/Concerns/Commenter.php
+++ b/src/Concerns/Commenter.php
@@ -6,7 +6,7 @@ namespace Akira\Commentable\Concerns;
 
 use Akira\Commentable\Contracts\CommentContract;
 use Akira\Commentable\Exceptions\DeleteCommentNotAllowedException;
-use Akira\Commentable\Models\Comment;
+use Akira\Commentable\Models\Message;
 use Akira\Commentable\Models\Reply;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
@@ -16,9 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 trait Commenter
 {
     /**
-     * Get the comments for the model.
-     *
-     * @return MorphMany<Comment, Commenter>
+     * @return MorphMany<Message, Commenter>
      */
     public function comments(): MorphMany
     {
@@ -27,8 +25,6 @@ trait Commenter
     }
 
     /**
-     * Get the replies for the model.
-     *
      * @return HasMany<Reply, Commenter>
      */
     public function replies(): HasMany
@@ -38,8 +34,6 @@ trait Commenter
     }
 
     /**
-     * The name of the commenter.
-     *
      * @throws Exception
      */
     public function comment(Model $model, string $comment): CommentContract
@@ -51,17 +45,15 @@ trait Commenter
     }
 
     /**
-     * Reply to a comment
+     * @phpstan-return CommentContract
      */
-    public function reply(Comment|Reply $comment, string $reply): CommentContract
+    public function reply(Message $comment, string $reply): CommentContract
     {
 
         return $comment->replies()->create($this->prepareCommentData($reply));
     }
 
     /**
-     * Delete a comment
-     *
      * @throws DeleteCommentNotAllowedException
      */
     public function deleteComment(CommentContract $comment): void
@@ -75,7 +67,7 @@ trait Commenter
     }
 
     /**
-     * Approve comment deletion
+     * @phpstan-return bool
      */
     public function approveCommentDeletion(CommentContract $comment): bool
     {
@@ -84,19 +76,15 @@ trait Commenter
     }
 
     /**
-     * force delete a comment
-     *
      * @throws Exception
      */
-    public function forceDeleteComment(Comment|Reply $comment): ?bool
+    public function forceDeleteComment(Message $comment): ?bool
     {
 
         return $comment->delete();
     }
 
     /**
-     * Force delete a comment
-     *
      * @throws Exception
      */
     private function requireCommentableTrait(Model $model): void
@@ -108,7 +96,7 @@ trait Commenter
     }
 
     /**
-     * Prepare the comment data
+     * @return array<string, mixed>
      */
     private function prepareCommentData(string $comment): array
     {

--- a/src/Models/BaseReaction.php
+++ b/src/Models/BaseReaction.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+abstract class BaseReaction extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'comment_id',
+        'type',
+        'owner_id',
+        'owner_type',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $table = config('commentable.reaction_table', 'reactions');
+        $this->table = is_string($table) ? $table : 'reactions';
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * @return BelongsTo<Model, $this> *
+     */
+    final public function user(): BelongsTo
+    {
+        return $this->belongsTo(
+            $this->configuredUserModel(),
+            $this->configuredUserForeignKey()
+        );
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    final public function owner(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return class-string<Model>
+     */
+    private function configuredUserModel(): string
+    {
+        $model = config('auth.providers.users.model');
+
+        if (is_string($model) && is_a($model, Model::class, true)) {
+            return $model;
+        }
+
+        return Model::class;
+    }
+
+    /**
+     * @phpstan-return non-empty-string
+     */
+    private function configuredUserForeignKey(): string
+    {
+        $foreignKey = config('commentable.user_foreign_key', 'user_id');
+
+        if (is_string($foreignKey) && $foreignKey !== '') {
+            return $foreignKey;
+        }
+
+        return 'user_id';
+    }
+}

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -19,7 +19,7 @@ abstract class Message extends Model implements CommentContract
     ];
 
     /**
-     * Get the table associated with the model.
+     * @param  array<string, mixed>  $attributes
      */
     public function __construct(array $attributes = [])
     {
@@ -29,8 +29,6 @@ abstract class Message extends Model implements CommentContract
     }
 
     /**
-     * Get the user that the comment belongs to.
-     *
      * @return MorphTo<Model, $this>
      */
     final public function commenter(): MorphTo
@@ -39,19 +37,15 @@ abstract class Message extends Model implements CommentContract
     }
 
     /**
-     * Get the reactions for the comment.
-     *
-     * @return HasMany<Reaction, $this>
+     * @return HasMany<BaseReaction, $this>
      */
     final public function reactions(): HasMany
     {
-        return $this->hasMany(Reaction::class, 'comment_id', 'id');
+        return $this->hasMany(self::configuredReactionModel(), 'comment_id', 'id');
 
     }
 
     /**
-     * Get the user  commenting the comment.
-     *
      * @return HasMany<Reply, $this>
      */
     final public function replies(): HasMany
@@ -60,8 +54,34 @@ abstract class Message extends Model implements CommentContract
     }
 
     /**
-     * The attributes that should be cast to native types.
-     *
+     * @return class-string<Message>
+     */
+    final protected static function configuredCommentModel(): string
+    {
+        $model = config('commentable.models.comment', Comment::class);
+
+        if (is_string($model) && is_a($model, self::class, true)) {
+            return $model;
+        }
+
+        return Comment::class;
+    }
+
+    /**
+     * @return class-string<BaseReaction>
+     */
+    final protected static function configuredReactionModel(): string
+    {
+        $model = config('commentable.models.reaction', Reaction::class);
+
+        if (is_string($model) && is_a($model, BaseReaction::class, true)) {
+            return $model;
+        }
+
+        return Reaction::class;
+    }
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/src/Models/Reaction.php
+++ b/src/Models/Reaction.php
@@ -4,44 +4,4 @@ declare(strict_types=1);
 
 namespace Akira\Commentable\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-
-final class Reaction extends Model
-{
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'comment_id',
-        'type',
-        'owner_id',
-        'owner_type',
-    ];
-
-    /**
-     * Get the table associated with the model.
-     *
-     * @return BelongsTo<Model, $this> *
-     */
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(
-            config('auth.providers.users.model'),
-            config('commentable', 'user_id')
-        );
-    }
-
-    /**
-     * Get the owner of the reaction.
-     *
-     * @return MorphTo<Model, $this>
-     */
-    public function owner(): MorphTo
-    {
-        return $this->morphTo();
-    }
-}
+final class Reaction extends BaseReaction {}

--- a/src/Models/Reply.php
+++ b/src/Models/Reply.php
@@ -17,12 +17,10 @@ final class Reply extends Message
     ];
 
     /**
-     * Get the comment that the reply belongs to.
-     *
-     * @return BelongsTo<Comment, $this>
+     * @return BelongsTo<Message, $this>
      */
     public function comment(): BelongsTo
     {
-        return $this->belongsTo(Comment::class);
+        return $this->belongsTo(self::configuredCommentModel(), 'reply_id', 'id');
     }
 }

--- a/tests/CustomConfigurationTest.php
+++ b/tests/CustomConfigurationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Commentable\Tests\Fixtures\CustomComment;
+use Akira\Commentable\Tests\Fixtures\CustomReaction;
+use Akira\Commentable\Tests\Fixtures\Post;
+use Akira\Commentable\Tests\Fixtures\User;
+use Akira\Commentable\Tests\Support\CustomConfigurationTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+uses(CustomConfigurationTestCase::class, RefreshDatabase::class);
+
+it('respects custom models and table names', function (): void {
+    expect(Schema::hasTable('custom_comments'))->toBeTrue()
+        ->and(Schema::hasTable('custom_reactions'))->toBeTrue()
+        ->and(Schema::hasTable('comments'))->toBeFalse()
+        ->and(Schema::hasTable('reactions'))->toBeFalse();
+
+    $user = User::query()->create([
+        'name' => 'Ada Lovelace',
+        'email' => 'ada@example.com',
+    ]);
+
+    $post = Post::query()->create([
+        'name' => 'Release notes',
+        'user_id' => $user->id,
+    ]);
+
+    $comment = $user->comment($post, 'Ship the package update.');
+
+    $reaction = $comment->reactions()->create([
+        'type' => 'like',
+        'owner_type' => $user::class,
+        'owner_id' => $user->id,
+    ]);
+
+    $reply = $user->reply($comment, 'Confirmed.');
+
+    expect($comment)->toBeInstanceOf(CustomComment::class)
+        ->and($comment->commenter)->toBeInstanceOf(User::class)
+        ->and($post->comments()->first())->toBeInstanceOf(CustomComment::class)
+        ->and($reaction)->toBeInstanceOf(CustomReaction::class)
+        ->and($reaction->owner)->toBeInstanceOf(User::class)
+        ->and($comment->reactions()->first())->toBeInstanceOf(CustomReaction::class)
+        ->and($reply->comment)->toBeInstanceOf(CustomComment::class);
+});
+
+it('uses custom table names on migration rollback', function (): void {
+    $migration = include __DIR__.'/../database/migrations/create_commentable_table.php';
+
+    $migration->down();
+
+    expect(Schema::hasTable('custom_comments'))->toBeFalse()
+        ->and(Schema::hasTable('custom_reactions'))->toBeFalse();
+});

--- a/tests/Fixtures/CustomComment.php
+++ b/tests/Fixtures/CustomComment.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Tests\Fixtures;
+
+use Akira\Commentable\Models\Message;
+
+final class CustomComment extends Message {}

--- a/tests/Fixtures/CustomReaction.php
+++ b/tests/Fixtures/CustomReaction.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Tests\Fixtures;
+
+use Akira\Commentable\Models\BaseReaction;
+
+final class CustomReaction extends BaseReaction {}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,7 +7,7 @@ use Akira\Commentable\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(TestCase::class, RefreshDatabase::class)
-    ->in(__DIR__);
+    ->in(__DIR__.'/Fixtures');
 
 function user(): User
 {

--- a/tests/Support/CustomConfigurationTestCase.php
+++ b/tests/Support/CustomConfigurationTestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Tests\Support;
+
+use Akira\Commentable\Tests\Fixtures\CustomComment;
+use Akira\Commentable\Tests\Fixtures\CustomReaction;
+use Akira\Commentable\Tests\TestCase;
+
+abstract class CustomConfigurationTestCase extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        config()->set('commentable.comment_table', 'custom_comments');
+        config()->set('commentable.reaction_table', 'custom_reactions');
+        config()->set('commentable.models.comment', CustomComment::class);
+        config()->set('commentable.models.reaction', CustomReaction::class);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,8 @@ abstract class TestCase extends Orchestra
     {
         config()->set('database.default', 'testing');
 
+        $this->defineEnvironment($app);
+
         $migrations = [
             __DIR__.'/../database/migrations',
             __DIR__.'/Fixtures/Migrations',
@@ -35,6 +37,8 @@ abstract class TestCase extends Orchestra
             }
         }
     }
+
+    protected function defineEnvironment($app): void {}
 
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
Problem:
Fixes #21. The package configuration exposed custom comment and reaction models and table names, but some relationships and migration rollback paths still ignored those keys.

Root cause:
`Message::reactions()` and `Reply::comment()` used concrete model classes, `Reaction` did not read the configured reaction table, and migration rollback referenced nonexistent nested table keys.

Solution:
- Add `BaseReaction` as the extension point for configured reaction models while keeping the default `Reaction` concrete model final.
- Resolve configured comment and reaction model classes in relationships.
- Use configured table names in reaction models and migration rollback.
- Add Pest coverage for custom models, custom tables, relationship loading, and rollback.
- Update configuration and schema docs to match the supported customization path.

Validation:
- `composer test`
- Pre-push `composer test`

Risk/rollback:
Low risk. The default `Comment` and `Reaction` classes remain available, and the configured model path is covered by regression tests. Roll back by reverting this commit if custom model resolution causes consumer-specific issues.
