### PR TITLE
ci(actions): harden release workflow (#26)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -34,8 +36,12 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           DEFAULT_BRANCH="$(git remote show origin | sed -n 's/.*HEAD branch: //p')"
           git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "chore(changelog): ${{ github.ref_name }}"
-          git push origin "HEAD:${DEFAULT_BRANCH}" || true
+          if git diff --cached --quiet; then
+            echo "CHANGELOG.md is already current."
+            exit 0
+          fi
+          git commit -m "chore(changelog): ${{ github.ref_name }}"
+          git push origin "HEAD:${DEFAULT_BRANCH}"
 
       - name: Extract release notes
         id: notes
@@ -59,16 +65,49 @@ jobs:
             --latest
 
       - name: Send GitHub Release to Discord
-        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682
-        with:
-          webhook_url: ${{ secrets.DISCORD }}
-          release_name: ${{ github.ref_name }}
-          release_body: ${{ steps.notes.outputs.body }}
-          release_html_url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
-          color: "2105893"
-          username: "Commentable"
-          avatar_url: "https://avatars.githubusercontent.com/u/116525492?s=96&v=4"
-          content: "||@everyone||"
-          footer_title: "Commentable"
-          footer_icon_url: "https://avatars.githubusercontent.com/u/116525492?s=96&v=4"
-          footer_timestamp: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD }}
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
+          RELEASE_NAME: ${{ github.ref_name }}
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+            echo "Discord webhook is not configured."
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import datetime
+          import json
+          import os
+          import urllib.request
+
+          payload = {
+              "content": "||@everyone||",
+              "username": "Commentable",
+              "avatar_url": "https://avatars.githubusercontent.com/u/116525492?s=96&v=4",
+              "embeds": [
+                  {
+                      "title": os.environ["RELEASE_NAME"],
+                      "url": os.environ["RELEASE_URL"],
+                      "description": os.environ["RELEASE_BODY"][:4096],
+                      "color": 2105893,
+                      "footer": {
+                          "text": "Commentable",
+                          "icon_url": "https://avatars.githubusercontent.com/u/116525492?s=96&v=4",
+                      },
+                      "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                  }
+              ],
+          }
+
+          request = urllib.request.Request(
+              os.environ["DISCORD_WEBHOOK_URL"],
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+
+          with urllib.request.urlopen(request, timeout=10) as response:
+              response.read()
+          PY

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -442,6 +442,14 @@ return $this->morphMany(config('commentable.models.comment'), 'commentable');
 
 ---
 
+## Release Workflow Checks
+
+The release workflow pins third-party actions to commit SHAs. When GitHub deprecates a JavaScript runtime, update the upstream action tag, resolve the tag to a commit SHA, and replace the pinned SHA in the workflow. If no compatible action exists, use a shell step instead of a JavaScript action.
+
+The changelog commit step must fail when the push fails. A failed changelog push means the release automation needs attention before the next tag.
+
+---
+
 ## Getting Help
 
 If you encounter issues not covered here:


### PR DESCRIPTION
Problem:
Fixes #26. The release workflow used an older checkout pin and a Discord JavaScript action that still runs on an older Node runtime. It also hid changelog push failures with `|| true`.

Root cause:
The workflow kept hash pins for supply-chain safety, but the pins and release notification step were not updated as GitHub action runtimes changed. The changelog push command swallowed failures, so release automation could succeed while leaving the repository changelog stale.

Solution:
- Update the release checkout pin to the `actions/checkout` v6 commit SHA, which uses `node24`.
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` at the job level.
- Replace the Node-based Discord release action with a Python webhook step because the current pinned Discord action still declares `node16`.
- Fail the release when a changelog push fails.
- Document the action hash upgrade and changelog failure policy.

Validation:
- Verified `actions/checkout@v6` resolves to `df4cb1c069e1874edd31b4311f1884172cec0e10` and declares `runs.using: node24`.
- Verified `SethCohen/github-releases-to-discord@v1.20.0` resolves to `24d166886aee4646d448c8a389ff9e1ebcab3682` and declares `runs.using: node16`.
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml ok'"`
- `composer test`
- Pre-push `composer test`

Risk/rollback:
Medium operational risk because the Discord notification path changed implementation. Release creation and changelog generation remain unchanged. Roll back by reverting this commit if the webhook payload needs adjustment.
