### PR TITLE
docs(package): fix metadata drift (#27)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/akira-io/commentable/discussions/new?category=q-a
+    url: https://github.com/akira-io/laravel-commentable/discussions/new?category=q-a
     about: Ask the community for help
   - name: Request a feature
-    url: https://github.com/akira-io/commentable/discussions/new?category=ideas
+    url: https://github.com/akira-io/laravel-commentable/discussions/new?category=ideas
     about: Share ideas for new features
   - name: Report a security issue
-    url: https://github.com/akira-io/commentable/security/policy
+    url: https://github.com/akira-io/laravel-commentable/security/policy
     about: Learn how to notify us for sensitive bugs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require akira/laravel-commentable
 ```json
 {
   "require": {
-    "akira/laravel-commentable": "^0.1"
+    "akira/laravel-commentable": "^0.2"
   }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "laravel",
         "commentable"
     ],
-    "homepage": "https://github.com/akira-io/commentable",
+    "homepage": "https://github.com/akira-io/laravel-commentable",
     "license": "MIT",
     "authors": [
         {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+it('does not reference the retired repository URL', function (): void {
+    $retiredRepositoryUrl = implode('/', ['github.com/akira-io', 'commentable']);
+
+    $paths = [
+        '.github',
+        'README.md',
+        'composer.json',
+        'docs',
+    ];
+
+    $matches = [];
+
+    foreach ($paths as $path) {
+        if (is_file($path)) {
+            if (str_contains((string) file_get_contents($path), $retiredRepositoryUrl)) {
+                $matches[] = $path;
+            }
+
+            continue;
+        }
+
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+
+        foreach ($files as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            if (str_contains((string) file_get_contents($file->getPathname()), $retiredRepositoryUrl)) {
+                $matches[] = $file->getPathname();
+            }
+        }
+    }
+
+    expect($matches)->toBeEmpty();
+});


### PR DESCRIPTION
Problem:
Fixes #27. Package docs and metadata still referenced the older repository and pre-v0.2 install constraint.

Root cause:
The package moved to `akira-io/laravel-commentable`, but README examples, Composer metadata, and issue template contact links were not all updated after the v0.2.0 release.

Solution:
- Update the README Composer constraint to `^0.2`.
- Point the Composer homepage to the active repository.
- Update issue template discussion and security links to `akira-io/laravel-commentable`.
- Add a Pest metadata guard that scans README, Composer metadata, docs, and GitHub templates for the retired repository URL.

Validation:
- Verified latest release is `v0.2.0`.
- `rg -n "akira-io/commentable|\^0\.1" README.md composer.json .github docs tests`
- `vendor/bin/pest tests/MetadataTest.php --compact`
- `composer test`
- Pre-push `composer test`

Risk/rollback:
Low risk. This is documentation and package metadata only. Roll back by reverting this commit if a downstream tool still expects the old repository URL.
