### PR TITLE
fix(package): authorize forced comment deletion (#14)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "test:refactor": "rector --dry-run",
         "test:types": "phpstan",
         "test:type-coverage": "pest --type-coverage --min=100 --compact",
-        "test:coverage": "pest --parallel --coverage --compact --exactly=83.8",
+        "test:coverage": "pest --parallel --coverage --compact --exactly=84.6",
         "test:typos": "peck",
         "test": [
             "@test:lint",

--- a/docs/02-basic-usage.md
+++ b/docs/02-basic-usage.md
@@ -125,16 +125,20 @@ The `deleteComment()` method:
 - Throws `DeleteCommentNotAllowedException` if the user doesn't own the comment
 - Soft or hard deletes based on your model configuration
 
-### Force Delete Any Comment
+### Force Delete With Explicit Approval
 
 ```php
-$user = User::find(1); // Admin or post owner
+$user = User::find(1);
 $comment = Comment::find(1);
 
-$user->forceDeleteComment($comment);
+try {
+    $user->forceDeleteComment($comment);
+} catch (\Akira\Commentable\Exceptions\DeleteCommentNotAllowedException $e) {
+    // User is not authorized to force delete this comment
+}
 ```
 
-Use `forceDeleteComment()` when you need to bypass ownership checks (e.g., moderators deleting inappropriate content).
+`forceDeleteComment()` calls `approveForcedCommentDeletion()` before deleting. Override that method on your commenter model when moderators or post owners need a separate deletion path.
 
 ## Relationships
 

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -181,28 +181,53 @@ if ($user->approveCommentDeletion($comment)) {
 
 ---
 
-##### `forceDeleteComment(Comment|Reply $comment): ?bool`
+##### `forceDeleteComment(Message $comment): ?bool`
 
-Force deletes a comment, bypassing authorization checks.
+Deletes a comment after `approveForcedCommentDeletion()` allows the action.
 
 ```php
-public function forceDeleteComment(Comment|Reply $comment): ?bool
+public function forceDeleteComment(Message $comment): ?bool
 ```
 
 **Parameters:**
-- `$comment` - The comment or reply to delete
+- `$comment` - The message to delete
 
 **Returns:** `?bool` - Result of the delete operation
 
-**Throws:** `Exception` - If delete operation fails
+**Throws:** `DeleteCommentNotAllowedException` - If user is not authorized to force delete the comment
 
 **Example:**
 ```php
 $admin = User::find(1);
 $comment = Comment::find(1);
 
-$admin->forceDeleteComment($comment); // Deletes regardless of ownership
+$admin->forceDeleteComment($comment);
 ```
+
+---
+
+##### `approveForcedCommentDeletion(CommentContract $comment): bool`
+
+Determines if the user can force delete a comment.
+
+```php
+public function approveForcedCommentDeletion(CommentContract $comment): bool
+```
+
+**Parameters:**
+- `$comment` - The comment to check
+
+**Returns:** `bool` - True if forced deletion is allowed, false otherwise
+
+**Example:**
+```php
+public function approveForcedCommentDeletion(CommentContract $comment): bool
+{
+    return $this->isModerator();
+}
+```
+
+**Note:** The default implementation falls back to `approveCommentDeletion()`.
 
 ---
 

--- a/docs/07-testing.md
+++ b/docs/07-testing.md
@@ -149,10 +149,10 @@ test('user cannot delete another users comment', function () {
 })->throws(DeleteCommentNotAllowedException::class);
 ```
 
-### Force Delete Bypasses Authorization
+### Force Delete Requires Explicit Approval
 
 ```php
-test('force delete bypasses authorization checks', function () {
+test('force delete rejects unauthorized users', function () {
     $user1 = User::create(['name' => 'John Doe']);
     $user2 = User::create(['name' => 'Jane Smith']);
     $post = Post::create(['title' => 'Test Post']);
@@ -160,9 +160,7 @@ test('force delete bypasses authorization checks', function () {
     $comment = $user1->comment($post, 'Johns comment');
     
     $user2->forceDeleteComment($comment);
-
-    expect($post->comments()->count())->toBe(0);
-});
+})->throws(DeleteCommentNotAllowedException::class);
 ```
 
 ## Testing Reactions

--- a/src/Concerns/Commenter.php
+++ b/src/Concerns/Commenter.php
@@ -76,12 +76,24 @@ trait Commenter
     }
 
     /**
-     * @throws Exception
+     * @throws DeleteCommentNotAllowedException
      */
     public function forceDeleteComment(Message $comment): ?bool
     {
+        if (! $this->approveForcedCommentDeletion($comment)) {
+            throw new DeleteCommentNotAllowedException();
+        }
 
         return $comment->delete();
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    public function approveForcedCommentDeletion(CommentContract $comment): bool
+    {
+
+        return $this->approveCommentDeletion($comment);
     }
 
     /**

--- a/tests/Fixtures/Feature/CommenterTest.php
+++ b/tests/Fixtures/Feature/CommenterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Akira\Commentable\Exceptions\DeleteCommentNotAllowedException;
 use Akira\Commentable\Models\Comment;
 use Akira\Commentable\Models\Reaction;
+use Akira\Commentable\Tests\Fixtures\ModeratorUser;
 use Akira\Commentable\Tests\Fixtures\Post;
 
 beforeEach(function (): void {
@@ -139,37 +140,39 @@ it('should not delete a reply that does not belongs to the user', function (): v
 
 });
 
-it('should delete a comment if your the post owner', function (): void {
+it('should not force delete a comment without approval', function (): void {
 
     $post = Post::query()->create(['name' => 'post1', 'user_id' => $this->user->id]);
 
     $comment = user()->comment($post, 'comment1');
 
-    $this->user->forceDeleteComment($comment);
+    expect(fn () => $this->user->forceDeleteComment($comment))
+        ->toThrow(DeleteCommentNotAllowedException::class);
 
     expect($post->comments)
-        ->toHaveCount(0);
+        ->toHaveCount(1);
 
 });
 
-it('should delete a reply if your the post owner', function (): void {
+it('should force delete a comment through explicit approval', function (): void {
 
     $post = Post::query()->create(['name' => 'post1', 'user_id' => $this->user->id]);
 
-    $comment = $this->user->comment($post, 'comment1');
+    $comment = user()->comment($post, 'comment1');
 
-    $reply = user()->reply($comment, 'reply1');
+    $moderator = ModeratorUser::query()->create([
+        'name' => 'moderator',
+        'email' => 'moderator@example.com',
+    ]);
 
-    $this->user->forceDeleteComment($reply);
+    $moderator->forceDeleteComment($comment);
 
     expect($post->comments)
-        ->toHaveCount(1)
-        ->and($comment->replies)
         ->toHaveCount(0);
 
 });
 
-it('should delete a reply to a reply if your the post owner', function (): void {
+it('should force delete a nested reply through explicit approval', function (): void {
 
     $post = Post::query()->create(['name' => 'post1', 'user_id' => $this->user->id]);
 
@@ -179,7 +182,12 @@ it('should delete a reply to a reply if your the post owner', function (): void 
 
     $reply2 = user()->reply($reply, 'reply2');
 
-    $this->user->forceDeleteComment($reply2);
+    $moderator = ModeratorUser::query()->create([
+        'name' => 'moderator',
+        'email' => 'moderator@example.com',
+    ]);
+
+    $moderator->forceDeleteComment($reply2);
 
     expect($post->comments)
         ->toHaveCount(1)

--- a/tests/Fixtures/ModeratorUser.php
+++ b/tests/Fixtures/ModeratorUser.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Tests\Fixtures;
+
+use Akira\Commentable\Concerns\Commenter;
+use Akira\Commentable\Contracts\CommentContract;
+use Illuminate\Database\Eloquent\Model;
+
+final class ModeratorUser extends Model
+{
+    use Commenter;
+
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public function approveForcedCommentDeletion(CommentContract $comment): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Problem:
Fixes #14. `forceDeleteComment()` could delete any supplied comment or reply without an authorization decision.

Root cause:
The public forced deletion path called `$comment->delete()` directly, while only the safer `deleteComment()` path checked ownership.

Solution:
- Route `forceDeleteComment()` through a new `approveForcedCommentDeletion()` hook.
- Default forced deletion approval to the existing ownership check.
- Add coverage proving unauthorized users cannot force delete another user's comment.
- Add a moderator fixture that explicitly approves forced deletion.
- Update usage, API, and testing docs so forced deletion is documented as an authorized path.

Validation:
- `vendor/bin/pest tests/Fixtures/Feature/CommenterTest.php --compact`
- `composer test`
- Pre-push `composer test`

Risk/rollback:
Medium risk because callers that relied on unguarded forced deletion now need to override `approveForcedCommentDeletion()`. Roll back by reverting this commit if a consuming app needs more time to adopt the explicit authorization hook.
