### PR TITLE
feat(package): add comment lifecycle gates (#15)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "test:refactor": "rector --dry-run",
         "test:types": "phpstan",
         "test:type-coverage": "pest --type-coverage --min=100 --compact",
-        "test:coverage": "pest --parallel --coverage --compact --exactly=84.6",
+        "test:coverage": "pest --parallel --coverage --compact --exactly=87.6",
         "test:typos": "peck",
         "test": [
             "@test:lint",

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -77,7 +77,7 @@ $userReplies = $user->replies; // All replies by this user
 
 ##### `comment(Model $model, string $comment): CommentContract`
 
-Creates a comment on a commentable model.
+Creates a comment on a commentable model. If the `commentable.comment` Gate is defined, it must allow the action. If that Gate is not defined, a Laravel policy registered for the target model can allow or deny the `comment` ability.
 
 ```php
 public function comment(Model $model, string $comment): CommentContract
@@ -90,6 +90,7 @@ public function comment(Model $model, string $comment): CommentContract
 **Returns:** `CommentContract` - The created comment instance
 
 **Throws:** `Exception` - If the model doesn't use the `Commentable` trait
+**Throws:** `AuthorizationException` - If the configured Gate or policy denies the action
 
 **Example:**
 ```php
@@ -103,7 +104,7 @@ $comment = $user->comment($post, 'Great article!');
 
 ##### `reply(Comment|Reply $comment, string $reply): CommentContract`
 
-Creates a reply to a comment or another reply.
+Creates a reply to a comment or another reply. If the `commentable.reply` Gate is defined, it must allow the action. If that Gate is not defined, a Laravel policy registered for the message can allow or deny the `reply` ability.
 
 ```php
 public function reply(Comment|Reply $comment, string $reply): CommentContract
@@ -114,6 +115,8 @@ public function reply(Comment|Reply $comment, string $reply): CommentContract
 - `$reply` - The reply content
 
 **Returns:** `CommentContract` - The created reply instance
+
+**Throws:** `AuthorizationException` - If the configured Gate or policy denies the action
 
 **Example:**
 ```php
@@ -127,7 +130,7 @@ $reply = $user->reply($comment, 'Thanks for sharing!');
 
 ##### `deleteComment(CommentContract $comment): void`
 
-Deletes a comment if the user is authorized.
+Deletes a comment if the user is authorized. The `commentable.delete` Gate is used first when registered. If no package Gate exists, a message policy `delete` method is used when available. If neither exists, `approveCommentDeletion()` keeps the default ownership check.
 
 ```php
 public function deleteComment(CommentContract $comment): void
@@ -177,7 +180,7 @@ if ($user->approveCommentDeletion($comment)) {
 }
 ```
 
-**Note:** Override this method to implement custom authorization logic.
+**Note:** Override this method to implement custom authorization logic when you are not using Gates or policies.
 
 ---
 
@@ -208,7 +211,7 @@ $admin->forceDeleteComment($comment);
 
 ##### `approveForcedCommentDeletion(CommentContract $comment): bool`
 
-Determines if the user can force delete a comment.
+Determines if the user can force delete a comment. The `commentable.forceDelete` Gate is used first when registered. If no package Gate exists, a message policy `forceDelete` method is used when available. If neither exists, the method falls back to `approveCommentDeletion()`.
 
 ```php
 public function approveForcedCommentDeletion(CommentContract $comment): bool
@@ -228,6 +231,87 @@ public function approveForcedCommentDeletion(CommentContract $comment): bool
 ```
 
 **Note:** The default implementation falls back to `approveCommentDeletion()`.
+
+---
+
+##### `approveComment(Message $comment): bool`
+
+Marks a comment or reply as approved after authorization. If the `commentable.approve` Gate is defined, it must allow the action. If that Gate is not defined, a Laravel policy registered for the message can allow or deny the `approve` ability.
+
+```php
+public function approveComment(Message $comment): bool
+```
+
+**Parameters:**
+- `$comment` - The message to approve
+
+**Returns:** `bool` - Result of the save operation
+
+**Throws:** `AuthorizationException` - If the configured Gate or policy denies the action
+
+**Example:**
+```php
+$moderator = User::find(1);
+$comment = Comment::find(1);
+
+$moderator->approveComment($comment);
+```
+
+---
+
+##### `rejectComment(Message $comment): bool`
+
+Marks a comment or reply as not approved after authorization. If the `commentable.reject` Gate is defined, it must allow the action. If that Gate is not defined, a Laravel policy registered for the message can allow or deny the `reject` ability.
+
+```php
+public function rejectComment(Message $comment): bool
+```
+
+**Parameters:**
+- `$comment` - The message to reject
+
+**Returns:** `bool` - Result of the save operation
+
+**Throws:** `AuthorizationException` - If the configured Gate or policy denies the action
+
+**Example:**
+```php
+$moderator = User::find(1);
+$comment = Comment::find(1);
+
+$moderator->rejectComment($comment);
+```
+
+---
+
+#### Authorization Abilities
+
+Register package Gates for global lifecycle rules:
+
+```php
+use Illuminate\Support\Facades\Gate;
+
+Gate::define('commentable.comment', fn (User $user, Post $post, string $content) => true);
+Gate::define('commentable.reply', fn (User $user, Message $message, string $content) => true);
+Gate::define('commentable.delete', fn (User $user, Message $message) => true);
+Gate::define('commentable.forceDelete', fn (User $user, Message $message) => true);
+Gate::define('commentable.approve', fn (User $user, Message $message) => true);
+Gate::define('commentable.reject', fn (User $user, Message $message) => true);
+```
+
+For per-model customization, register Laravel policies with matching methods:
+
+```php
+class PostPolicy
+{
+    public function comment(User $user, Post $post, string $content): bool
+    {
+        return $post->acceptsComments();
+    }
+}
+```
+
+Package Gates take precedence over model policies. When neither is registered, comment creation and replies stay allowed, deletion keeps the ownership fallback, forced deletion falls back to deletion approval, and approval methods save the requested approval state.
 
 ---
 

--- a/src/Concerns/Commenter.php
+++ b/src/Concerns/Commenter.php
@@ -9,12 +9,26 @@ use Akira\Commentable\Exceptions\DeleteCommentNotAllowedException;
 use Akira\Commentable\Models\Message;
 use Akira\Commentable\Models\Reply;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Gate;
 
 trait Commenter
 {
+    private const GATE_COMMENT = 'commentable.comment';
+
+    private const GATE_REPLY = 'commentable.reply';
+
+    private const GATE_DELETE = 'commentable.delete';
+
+    private const GATE_FORCE_DELETE = 'commentable.forceDelete';
+
+    private const GATE_APPROVE = 'commentable.approve';
+
+    private const GATE_REJECT = 'commentable.reject';
+
     /**
      * @return MorphMany<Message, Commenter>
      */
@@ -35,11 +49,13 @@ trait Commenter
 
     /**
      * @throws Exception
+     * @throws AuthorizationException
      */
     public function comment(Model $model, string $comment): CommentContract
     {
 
         $this->requireCommentableTrait($model);
+        $this->authorizeLifecycleAction(self::GATE_COMMENT, 'comment', $model, $comment);
 
         return $model->comments()->create($this->prepareCommentData($comment));
     }
@@ -49,6 +65,8 @@ trait Commenter
      */
     public function reply(Message $comment, string $reply): CommentContract
     {
+
+        $this->authorizeLifecycleAction(self::GATE_REPLY, 'reply', $comment, $reply);
 
         return $comment->replies()->create($this->prepareCommentData($reply));
     }
@@ -72,6 +90,12 @@ trait Commenter
     public function approveCommentDeletion(CommentContract $comment): bool
     {
 
+        $authorized = $this->allowsLifecycleAction(self::GATE_DELETE, 'delete', $comment);
+
+        if (is_bool($authorized)) {
+            return $authorized;
+        }
+
         return $this->getKey() === $comment->commenter_id;
     }
 
@@ -93,7 +117,37 @@ trait Commenter
     public function approveForcedCommentDeletion(CommentContract $comment): bool
     {
 
+        $authorized = $this->allowsLifecycleAction(self::GATE_FORCE_DELETE, 'forceDelete', $comment);
+
+        if (is_bool($authorized)) {
+            return $authorized;
+        }
+
         return $this->approveCommentDeletion($comment);
+    }
+
+    /**
+     * @phpstan-return bool
+     *
+     * @throws AuthorizationException
+     */
+    public function approveComment(Message $comment): bool
+    {
+        $this->authorizeLifecycleAction(self::GATE_APPROVE, 'approve', $comment);
+
+        return $comment->forceFill(['approved' => true])->save();
+    }
+
+    /**
+     * @phpstan-return bool
+     *
+     * @throws AuthorizationException
+     */
+    public function rejectComment(Message $comment): bool
+    {
+        $this->authorizeLifecycleAction(self::GATE_REJECT, 'reject', $comment);
+
+        return $comment->forceFill(['approved' => false])->save();
     }
 
     /**
@@ -105,6 +159,50 @@ trait Commenter
         if (! in_array(Commentable::class, class_uses($model))) {
             throw new Exception('The model must use the Commentable trait');
         }
+    }
+
+    /**
+     * @phpstan-return void
+     *
+     * @throws AuthorizationException
+     */
+    private function authorizeLifecycleAction(string $gateAbility, string $policyAbility, object $subject, mixed ...$arguments): void
+    {
+        if (Gate::has($gateAbility)) {
+            Gate::forUser($this)->authorize($gateAbility, [$subject, ...$arguments]);
+
+            return;
+        }
+
+        if ($this->hasPolicyAbility($subject, $policyAbility)) {
+            Gate::forUser($this)->authorize($policyAbility, [$subject, ...$arguments]);
+        }
+    }
+
+    /**
+     * @phpstan-return bool|null
+     */
+    private function allowsLifecycleAction(string $gateAbility, string $policyAbility, object $subject, mixed ...$arguments): ?bool
+    {
+        if (Gate::has($gateAbility)) {
+            return Gate::forUser($this)->allows($gateAbility, [$subject, ...$arguments]);
+        }
+
+        if ($this->hasPolicyAbility($subject, $policyAbility)) {
+            return Gate::forUser($this)->allows($policyAbility, [$subject, ...$arguments]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    private function hasPolicyAbility(object $subject, string $ability): bool
+    {
+        $policy = Gate::getPolicyFor($subject);
+
+        return is_object($policy) && method_exists($policy, $ability);
     }
 
     /**

--- a/tests/Fixtures/Feature/CommenterAuthorizationTest.php
+++ b/tests/Fixtures/Feature/CommenterAuthorizationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Commentable\Exceptions\DeleteCommentNotAllowedException;
+use Akira\Commentable\Tests\Fixtures\Post;
+use Akira\Commentable\Tests\Fixtures\PostPolicy;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function (): void {
+    $this->user = user();
+    $this->post = Post::query()->create(['name' => 'post1', 'user_id' => $this->user->id]);
+});
+
+it('keeps comment lifecycle actions available without gates', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+    $reply = $this->user->reply($comment, 'reply1');
+
+    expect($this->user->approveComment($comment))->toBeTrue()
+        ->and($comment->fresh()->approved)->toBeTrue()
+        ->and($this->user->rejectComment($reply))->toBeTrue()
+        ->and($reply->fresh()->approved)->toBeFalse();
+});
+
+it('denies comment creation through package gates', function (): void {
+    Gate::define('commentable.comment', fn ($user, Post $post, string $comment): bool => false);
+
+    expect(fn () => $this->user->comment($this->post, 'blocked'))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('authorizes comment creation through model policies', function (): void {
+    Gate::policy(Post::class, PostPolicy::class);
+
+    expect(fn () => $this->user->comment($this->post, 'blocked'))
+        ->toThrow(AuthorizationException::class);
+
+    expect($this->user->comment($this->post, 'allowed comment')->content)
+        ->toBe('allowed comment');
+});
+
+it('denies replies through package gates', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+
+    Gate::define('commentable.reply', fn ($user, $message, string $reply): bool => false);
+
+    expect(fn () => $this->user->reply($comment, 'blocked'))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('uses package gates for delete decisions before ownership fallback', function (): void {
+    $comment = user()->comment($this->post, 'comment1');
+
+    Gate::define('commentable.delete', fn ($user, $message): bool => true);
+
+    $this->user->deleteComment($comment);
+
+    expect($this->post->comments)->toHaveCount(0);
+});
+
+it('returns deterministic delete exceptions when package gates deny', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+
+    Gate::define('commentable.delete', fn ($user, $message): bool => false);
+
+    expect(fn () => $this->user->deleteComment($comment))
+        ->toThrow(DeleteCommentNotAllowedException::class);
+});
+
+it('uses package gates for force delete decisions', function (): void {
+    $comment = user()->comment($this->post, 'comment1');
+
+    Gate::define('commentable.forceDelete', fn ($user, $message): bool => true);
+
+    $this->user->forceDeleteComment($comment);
+
+    expect($this->post->comments)->toHaveCount(0);
+});
+
+it('authorizes approval and rejection through package gates', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+
+    Gate::define('commentable.approve', fn ($user, $message): bool => false);
+    Gate::define('commentable.reject', fn ($user, $message): bool => true);
+
+    expect(fn () => $this->user->approveComment($comment))
+        ->toThrow(AuthorizationException::class)
+        ->and($this->user->rejectComment($comment))->toBeTrue()
+        ->and($comment->fresh()->approved)->toBeFalse();
+});

--- a/tests/Fixtures/PostPolicy.php
+++ b/tests/Fixtures/PostPolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Tests\Fixtures;
+
+final class PostPolicy
+{
+    public function comment(User $user, Post $post, string $comment): bool
+    {
+        return str_starts_with($comment, 'allowed');
+    }
+}


### PR DESCRIPTION
Problem: #15 asks for Laravel policy and Gate integration across comment lifecycle actions.

Root cause: Commenter only exposed deletion ownership hooks, so creation, replies, force deletion, approval, and rejection could not use Laravel authorization consistently.

Solution: Added package Gate abilities for comment, reply, delete, forceDelete, approve, and reject actions, with Laravel policy fallback when package Gates are not registered. Existing deletion fallback methods remain compatible. Added approval and rejection helpers and documented authorization behavior.

Validation: composer test

Risk/rollback: Low. Apps without registered Gates or policies keep existing comment, reply, and deletion behavior. Roll back this commit if a consumer needs to remove the new authorization surface.

Fixes #15