### PR TITLE
feat(package): add moderation queue APIs (#16)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "test:refactor": "rector --dry-run",
         "test:types": "phpstan",
         "test:type-coverage": "pest --type-coverage --min=100 --compact",
-        "test:coverage": "pest --parallel --coverage --compact --exactly=84.6",
+        "test:coverage": "pest --parallel --coverage --compact --exactly=88.6",
         "test:typos": "peck",
         "test": [
             "@test:lint",

--- a/docs/03-advanced-features.md
+++ b/docs/03-advanced-features.md
@@ -73,19 +73,41 @@ echo $comment->approved; // false
 ### Querying Approved Comments
 
 ```php
-// Get only approved comments
-$approvedComments = $post->comments()->where('approved', true)->get();
+$approvedComments = $post->comments()->approved()->get();
 
-// Get pending comments
-$pendingComments = $post->comments()->where('approved', false)->get();
+$pendingComments = $post->comments()->pending()->get();
 ```
 
 ### Approving Comments
 
 ```php
 $comment = Comment::find(1);
-$comment->approved = true;
-$comment->save();
+
+$comment->approve();
+```
+
+### Rejecting Comments
+
+```php
+$comment = Comment::find(1);
+
+$comment->reject();
+```
+
+### Marking Comments Pending
+
+```php
+$comment = Comment::find(1);
+
+$comment->markPending();
+```
+
+### Bulk Moderation
+
+```php
+$comments = Comment::pending()->latest()->take(20)->get();
+
+Comment::approveMany($comments);
 ```
 
 ### Building a Moderation Queue
@@ -93,11 +115,28 @@ $comment->save();
 ```php
 use Akira\Commentable\Models\Comment;
 
-// Get all pending comments across all models
-$pending = Comment::where('approved', false)
+$pending = Comment::pending()
     ->with(['commenter', 'commentable'])
     ->orderBy('created_at', 'desc')
     ->paginate(20);
+```
+
+### Moderation Events
+
+The package dispatches `CommentApproved` after `approve()` and `CommentRejected` after `reject()`:
+
+```php
+use Akira\Commentable\Events\CommentApproved;
+use Akira\Commentable\Events\CommentRejected;
+use Illuminate\Support\Facades\Event;
+
+Event::listen(CommentApproved::class, function (CommentApproved $event): void {
+    $comment = $event->comment;
+});
+
+Event::listen(CommentRejected::class, function (CommentRejected $event): void {
+    $comment = $event->comment;
+});
 ```
 
 ## Custom Authorization

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -302,6 +302,127 @@ $replies = $comment->replies; // All replies to this comment
 
 ---
 
+##### `approve(): bool`
+
+Marks a comment or reply as approved and dispatches `CommentApproved`.
+
+```php
+final public function approve(): bool
+```
+
+**Returns:** `bool` - Result of the save operation
+
+**Example:**
+```php
+$comment = Comment::find(1);
+
+$comment->approve();
+```
+
+---
+
+##### `reject(): bool`
+
+Marks a comment or reply as pending and dispatches `CommentRejected`.
+
+```php
+final public function reject(): bool
+```
+
+**Returns:** `bool` - Result of the save operation
+
+**Example:**
+```php
+$comment = Comment::find(1);
+
+$comment->reject();
+```
+
+---
+
+##### `markPending(): bool`
+
+Marks a comment or reply as pending without dispatching a rejection event.
+
+```php
+final public function markPending(): bool
+```
+
+**Returns:** `bool` - Result of the save operation
+
+**Example:**
+```php
+$comment = Comment::find(1);
+
+$comment->markPending();
+```
+
+---
+
+##### `scopeApproved(Builder $query): Builder`
+
+Filters approved comments or replies.
+
+```php
+final public function scopeApproved(Builder $query): Builder
+```
+
+**Example:**
+```php
+$approvedComments = Comment::approved()->get();
+```
+
+---
+
+##### `scopePending(Builder $query): Builder`
+
+Filters pending comments or replies.
+
+```php
+final public function scopePending(Builder $query): Builder
+```
+
+**Example:**
+```php
+$pendingComments = Comment::pending()->get();
+```
+
+---
+
+##### `approveMany(iterable $comments): int`
+
+Approves each message in an iterable and returns the number of successful saves.
+
+```php
+final public static function approveMany(iterable $comments): int
+```
+
+**Example:**
+```php
+$comments = Comment::pending()->get();
+
+Comment::approveMany($comments);
+```
+
+---
+
+##### `rejectMany(iterable $comments): int`
+
+Rejects each message in an iterable and returns the number of successful saves.
+
+```php
+final public static function rejectMany(iterable $comments): int
+```
+
+**Example:**
+```php
+$comments = Comment::approved()->get();
+
+Comment::rejectMany($comments);
+```
+
+---
+
 ### Comment
 
 **Namespace:** `Akira\Commentable\Models\Comment`
@@ -457,6 +578,26 @@ try {
     return response()->json(['error' => $e->getMessage()], 403);
 }
 ```
+
+## Events
+
+### CommentApproved
+
+**Namespace:** `Akira\Commentable\Events\CommentApproved`
+
+Dispatched after `Message::approve()` saves an approved state.
+
+**Properties:**
+- `comment` - The approved `Message`
+
+### CommentRejected
+
+**Namespace:** `Akira\Commentable\Events\CommentRejected`
+
+Dispatched after `Message::reject()` saves a pending state.
+
+**Properties:**
+- `comment` - The rejected `Message`
 
 ---
 

--- a/src/Events/CommentApproved.php
+++ b/src/Events/CommentApproved.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Events;
+
+use Akira\Commentable\Models\Message;
+use Illuminate\Queue\SerializesModels;
+
+final class CommentApproved
+{
+    use SerializesModels;
+
+    /**
+     * @return void
+     */
+    public function __construct(public Message $comment) {}
+}

--- a/src/Events/CommentApproved.php
+++ b/src/Events/CommentApproved.php
@@ -12,7 +12,7 @@ final class CommentApproved
     use SerializesModels;
 
     /**
-     * @return void
+     * @phpstan-return void
      */
     public function __construct(public Message $comment) {}
 }

--- a/src/Events/CommentRejected.php
+++ b/src/Events/CommentRejected.php
@@ -12,7 +12,7 @@ final class CommentRejected
     use SerializesModels;
 
     /**
-     * @return void
+     * @phpstan-return void
      */
     public function __construct(public Message $comment) {}
 }

--- a/src/Events/CommentRejected.php
+++ b/src/Events/CommentRejected.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Events;
+
+use Akira\Commentable\Models\Message;
+use Illuminate\Queue\SerializesModels;
+
+final class CommentRejected
+{
+    use SerializesModels;
+
+    /**
+     * @return void
+     */
+    public function __construct(public Message $comment) {}
+}

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace Akira\Commentable\Models;
 
 use Akira\Commentable\Contracts\CommentContract;
+use Akira\Commentable\Events\CommentApproved;
+use Akira\Commentable\Events\CommentRejected;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+/**
+ * @property bool $approved
+ */
 abstract class Message extends Model implements CommentContract
 {
     protected $fillable = [
@@ -26,6 +32,42 @@ abstract class Message extends Model implements CommentContract
         $this->table = config('commentable.comment_table', 'comments');
 
         parent::__construct($attributes);
+    }
+
+    /**
+     * @param  iterable<array-key, Message>  $comments
+     *
+     * @phpstan-return int
+     */
+    final public static function approveMany(iterable $comments): int
+    {
+        $approvedCount = 0;
+
+        foreach ($comments as $comment) {
+            if ($comment->approve()) {
+                $approvedCount++;
+            }
+        }
+
+        return $approvedCount;
+    }
+
+    /**
+     * @param  iterable<array-key, Message>  $comments
+     *
+     * @phpstan-return int
+     */
+    final public static function rejectMany(iterable $comments): int
+    {
+        $rejectedCount = 0;
+
+        foreach ($comments as $comment) {
+            if ($comment->reject()) {
+                $rejectedCount++;
+            }
+        }
+
+        return $rejectedCount;
     }
 
     /**
@@ -51,6 +93,60 @@ abstract class Message extends Model implements CommentContract
     final public function replies(): HasMany
     {
         return $this->hasMany(Reply::class, 'reply_id', 'id');
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    final public function approve(): bool
+    {
+        $approved = $this->forceFill(['approved' => true])->save();
+
+        if ($approved) {
+            event(new CommentApproved($this));
+        }
+
+        return $approved;
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    final public function reject(): bool
+    {
+        $rejected = $this->markPending();
+
+        if ($rejected) {
+            event(new CommentRejected($this));
+        }
+
+        return $rejected;
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    final public function markPending(): bool
+    {
+        return $this->forceFill(['approved' => false])->save();
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    final public function scopeApproved(Builder $query): Builder
+    {
+        return $query->where('approved', true);
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    final public function scopePending(Builder $query): Builder
+    {
+        return $query->where('approved', false);
     }
 
     /**

--- a/tests/Fixtures/Feature/MessageModerationTest.php
+++ b/tests/Fixtures/Feature/MessageModerationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Commentable\Events\CommentApproved;
+use Akira\Commentable\Events\CommentRejected;
+use Akira\Commentable\Models\Comment;
+use Akira\Commentable\Tests\Fixtures\Post;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function (): void {
+    $this->user = user();
+    $this->post = Post::query()->create([
+        'name' => 'post1',
+        'user_id' => $this->user->id,
+    ]);
+});
+
+it('approves rejects and marks messages pending', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+    $reply = $this->user->reply($comment, 'reply1');
+
+    expect($comment->approve())->toBeTrue()
+        ->and($comment->fresh()->approved)->toBeTrue()
+        ->and($reply->approve())->toBeTrue()
+        ->and($reply->fresh()->approved)->toBeTrue()
+        ->and($comment->reject())->toBeTrue()
+        ->and($comment->fresh()->approved)->toBeFalse()
+        ->and($reply->markPending())->toBeTrue()
+        ->and($reply->fresh()->approved)->toBeFalse();
+});
+
+it('filters approved and pending messages with scopes', function (): void {
+    $approved = $this->user->comment($this->post, 'approved');
+    $pending = $this->user->comment($this->post, 'pending');
+
+    $approved->approve();
+
+    expect(Comment::query()->approved()->pluck('content')->all())
+        ->toBe(['approved'])
+        ->and(Comment::query()->pending()->pluck('content')->all())
+        ->toBe(['pending']);
+});
+
+it('bulk approves and rejects messages', function (): void {
+    $first = $this->user->comment($this->post, 'first');
+    $second = $this->user->comment($this->post, 'second');
+
+    expect(Comment::approveMany([$first, $second]))->toBe(2)
+        ->and($first->fresh()->approved)->toBeTrue()
+        ->and($second->fresh()->approved)->toBeTrue()
+        ->and(Comment::rejectMany([$first, $second]))->toBe(2)
+        ->and($first->fresh()->approved)->toBeFalse()
+        ->and($second->fresh()->approved)->toBeFalse();
+});
+
+it('emits moderation events for approval and rejection', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+
+    Event::fake([CommentApproved::class, CommentRejected::class]);
+
+    $comment->approve();
+    $comment->reject();
+
+    Event::assertDispatched(CommentApproved::class, fn (CommentApproved $event): bool => $event->comment->is($comment));
+    Event::assertDispatched(CommentRejected::class, fn (CommentRejected $event): bool => $event->comment->is($comment));
+});


### PR DESCRIPTION
Problem: #16 asks for first-class moderation APIs, scopes, bulk workflows, and events for approved comment state.

Root cause: The schema includes the approved flag, but consumers had to update it manually and duplicate moderation queries in application code.

Solution: Added Message moderation methods, approved and pending scopes, bulk approve and reject helpers, approval and rejection events, focused tests, and updated docs.

Validation: composer test

Risk/rollback: Low. Existing direct field updates still work. Roll back this commit if a consumer needs to remove the new moderation API surface.

Fixes #16