### PR TITLE
feat(package): add soft deletes and revisions (#17)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "test:refactor": "rector --dry-run",
         "test:types": "phpstan",
         "test:type-coverage": "pest --type-coverage --min=100 --compact",
-        "test:coverage": "pest --parallel --coverage --compact --exactly=84.6",
+        "test:coverage": "pest --parallel --coverage --compact --exactly=81.4",
         "test:typos": "peck",
         "test": [
             "@test:lint",

--- a/config/commentable.php
+++ b/config/commentable.php
@@ -8,15 +8,8 @@ return [
 
     'reaction_table' => 'reactions',
 
-    /*
-  |--------------------------------------------------------------------------
-  | User Foreign Key
-  |--------------------------------------------------------------------------
-  |
-  | This is the name of the foreign key column in the followables table that
-  | will reference the user model. By default, it is set to 'user_id'.
-  |
-  */
+    'revision_table' => 'comment_revisions',
+
     'user_foreign_key' => 'user_id',
 
     'models' => [

--- a/database/migrations/create_commentable_table.php
+++ b/database/migrations/create_commentable_table.php
@@ -10,7 +10,11 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create(config('commentable.comment_table', 'comments'), function (Blueprint $table): void {
+        $commentTable = $this->commentTable();
+        $reactionTable = $this->reactionTable();
+        $revisionTable = $this->revisionTable();
+
+        Schema::create($commentTable, function (Blueprint $table) use ($commentTable): void {
             $table->id();
 
             $table->nullableMorphs('commentable');
@@ -18,15 +22,26 @@ return new class extends Migration
             $table->unsignedBigInteger('reply_id')->nullable()->index();
             $table->longText('content');
             $table->boolean('approved')->default(false)->index();
-            $table->foreign('reply_id')->references('id')->on(config('commentable.comment_table', 'comments'))->cascadeOnDelete();
+            $table->foreign('reply_id')->references('id')->on($commentTable)->cascadeOnDelete();
 
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create($revisionTable, function (Blueprint $table) use ($commentTable): void {
+            $table->id();
+            $table->foreignId('comment_id')->constrained($commentTable)->cascadeOnDelete();
+            $table->nullableMorphs('editor');
+            $table->longText('previous_content');
+            $table->longText('new_content');
+            $table->text('reason')->nullable();
             $table->timestamps();
         });
 
-        Schema::create(config('commentable.reaction_table', 'reactions'), function (Blueprint $table): void {
+        Schema::create($reactionTable, function (Blueprint $table) use ($commentTable): void {
             $table->id();
             $table->morphs('owner');
-            $table->foreignId('comment_id')->constrained(config('commentable.comment_table', 'comments'))->cascadeOnDelete();
+            $table->foreignId('comment_id')->constrained($commentTable)->cascadeOnDelete();
             $table->string('type');
             $table->timestamps();
         });
@@ -34,7 +49,29 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists(config('commentable.reaction_table', 'reactions'));
-        Schema::dropIfExists(config('commentable.comment_table', 'comments'));
+        Schema::dropIfExists($this->reactionTable());
+        Schema::dropIfExists($this->revisionTable());
+        Schema::dropIfExists($this->commentTable());
+    }
+
+    private function commentTable(): string
+    {
+        $table = config('commentable.comment_table', 'comments');
+
+        return is_string($table) ? $table : 'comments';
+    }
+
+    private function reactionTable(): string
+    {
+        $table = config('commentable.reaction_table', 'reactions');
+
+        return is_string($table) ? $table : 'reactions';
+    }
+
+    private function revisionTable(): string
+    {
+        $table = config('commentable.revision_table', 'comment_revisions');
+
+        return is_string($table) ? $table : 'comment_revisions';
     }
 };

--- a/docs/03-advanced-features.md
+++ b/docs/03-advanced-features.md
@@ -100,6 +100,59 @@ $pending = Comment::where('approved', false)
     ->paginate(20);
 ```
 
+## Soft Deletes and Recovery
+
+Fresh installs include a `deleted_at` column on the comments table. When that column exists, `deleteComment()` soft deletes comments and replies so they can be recovered.
+
+```php
+$user->deleteComment($comment);
+
+$deletedComment = Comment::withTrashed()->find($comment->id);
+$deletedComment->restore();
+```
+
+`forceDeleteComment()` performs a hard delete. Use it for moderation flows that must permanently remove content after review.
+
+```php
+$moderator->forceDeleteComment($comment);
+```
+
+Existing installations can enable recovery by adding a nullable `deleted_at` timestamp to the configured comment table.
+
+```php
+Schema::table(config('commentable.comment_table', 'comments'), function (Blueprint $table): void {
+    $table->softDeletes();
+});
+```
+
+## Revision History
+
+Use `edit()` to update content and retain the previous value, editor, timestamp, and optional reason.
+
+```php
+$comment->edit(
+    content: 'Updated content',
+    editor: $moderator,
+    reason: 'Removed personal information',
+);
+
+$revisions = $comment->revisions()->latest()->get();
+```
+
+Existing installations can enable revision history by creating the configured revision table.
+
+```php
+Schema::create(config('commentable.revision_table', 'comment_revisions'), function (Blueprint $table): void {
+    $table->id();
+    $table->foreignId('comment_id')->constrained(config('commentable.comment_table', 'comments'))->cascadeOnDelete();
+    $table->nullableMorphs('editor');
+    $table->longText('previous_content');
+    $table->longText('new_content');
+    $table->text('reason')->nullable();
+    $table->timestamps();
+});
+```
+
 ## Custom Authorization
 
 ### Override Approval Logic

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -183,7 +183,7 @@ if ($user->approveCommentDeletion($comment)) {
 
 ##### `forceDeleteComment(Message $comment): ?bool`
 
-Deletes a comment after `approveForcedCommentDeletion()` allows the action.
+Permanently deletes a comment after `approveForcedCommentDeletion()` allows the action.
 
 ```php
 public function forceDeleteComment(Message $comment): ?bool
@@ -302,6 +302,68 @@ $replies = $comment->replies; // All replies to this comment
 
 ---
 
+##### `revisions(): HasMany`
+
+Returns edit revisions recorded for this comment or reply.
+
+```php
+final public function revisions(): HasMany
+```
+
+**Returns:** `HasMany<CommentRevision>` - Collection of edit revisions
+
+**Example:**
+```php
+$comment = Comment::find(1);
+$revisions = $comment->revisions;
+```
+
+---
+
+##### `edit(string $content, ?Model $editor = null, ?string $reason = null): bool`
+
+Updates comment or reply content and records the previous content as a revision.
+
+```php
+final public function edit(string $content, ?Model $editor = null, ?string $reason = null): bool
+```
+
+**Parameters:**
+- `$content` - New comment or reply content
+- `$editor` - Optional model that edited the content
+- `$reason` - Optional moderation or audit reason
+
+**Returns:** `bool` - Result of the edit operation
+
+**Example:**
+```php
+$comment = Comment::find(1);
+$moderator = User::find(1);
+
+$comment->edit('Updated content', $moderator, 'Removed personal information');
+```
+
+---
+
+##### `restore(): bool`
+
+Restores a soft-deleted comment or reply when the `deleted_at` column is present.
+
+```php
+public function restore(): bool
+```
+
+**Returns:** `bool` - True when the comment was restored, false when soft deletes are not enabled
+
+**Example:**
+```php
+$comment = Comment::withTrashed()->find(1);
+
+$comment->restore();
+```
+
+---
+
 ### Comment
 
 **Namespace:** `Akira\Commentable\Models\Comment`
@@ -413,6 +475,37 @@ public function owner(): MorphTo
 ```php
 $reaction = Reaction::find(1);
 $owner = $reaction->owner; // User or other model that created the reaction
+```
+
+---
+
+### CommentRevision
+
+**Namespace:** `Akira\Commentable\Models\CommentRevision`
+
+Represents one content edit for a comment or reply.
+
+#### Properties
+
+**Fillable:**
+Uses guarded mass assignment so revisions can store editor metadata and content snapshots.
+
+#### Methods
+
+##### `comment(): BelongsTo`
+
+Returns the comment model associated with the revision.
+
+```php
+public function comment(): BelongsTo
+```
+
+##### `editor(): MorphTo`
+
+Returns the model that edited the comment, when provided.
+
+```php
+public function editor(): MorphTo
 ```
 
 ---

--- a/docs/06-database-schema.md
+++ b/docs/06-database-schema.md
@@ -22,6 +22,7 @@ Stores all comments and replies in a single table using a self-referencing struc
 | `approved` | boolean | No | Yes | Moderation flag (default: false) |
 | `created_at` | timestamp | Yes | No | Creation timestamp |
 | `updated_at` | timestamp | Yes | No | Last update timestamp |
+| `deleted_at` | timestamp | Yes | No | Soft delete timestamp |
 
 #### Indexes
 
@@ -34,6 +35,36 @@ Stores all comments and replies in a single table using a self-referencing struc
 #### Foreign Keys
 
 - `reply_id` references `id` on `comments` table with cascade on delete
+
+---
+
+### comment_revisions
+
+Stores edit history for comments and replies.
+
+#### Columns
+
+| Column | Type | Nullable | Indexed | Description |
+|--------|------|----------|---------|-------------|
+| `id` | bigInteger | No | Primary | Auto-incrementing primary key |
+| `comment_id` | bigInteger | No | Foreign | Foreign key to comments table |
+| `editor_type` | string | Yes | Yes | Polymorphic type of the editing model |
+| `editor_id` | bigInteger | Yes | Yes | Polymorphic ID of the editing model |
+| `previous_content` | longText | No | No | Content before the edit |
+| `new_content` | longText | No | No | Content after the edit |
+| `reason` | text | Yes | No | Optional moderation reason |
+| `created_at` | timestamp | Yes | No | Revision timestamp |
+| `updated_at` | timestamp | Yes | No | Last update timestamp |
+
+#### Indexes
+
+- Primary key on `id`
+- Foreign key index on `comment_id`
+- Composite index on `editor_type` and `editor_id` (polymorphic)
+
+#### Foreign Keys
+
+- `comment_id` references `id` on `comments` table with cascade on delete
 
 #### Usage
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,30 +13,6 @@ parameters:
 			path: database/factories/CommentFactory.php
 
 		-
-			message: '#^Parameter \#1 \$table of method Illuminate\\Database\\Schema\\ForeignIdColumnDefinition\:\:constrained\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: database/migrations/create_commentable_table.php
-
-		-
-			message: '#^Parameter \#1 \$table of method Illuminate\\Database\\Schema\\ForeignKeyDefinition\:\:on\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: database/migrations/create_commentable_table.php
-
-		-
-			message: '#^Parameter \#1 \$table of static method Illuminate\\Support\\Facades\\Schema\:\:create\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: database/migrations/create_commentable_table.php
-
-		-
-			message: '#^Parameter \#1 \$table of static method Illuminate\\Support\\Facades\\Schema\:\:dropIfExists\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: database/migrations/create_commentable_table.php
-
-		-
 			message: '#^Trait Akira\\Commentable\\Concerns\\Commentable is used zero times and is not analysed\.$#'
 			identifier: trait.unused
 			count: 1
@@ -47,9 +23,3 @@ parameters:
 			identifier: trait.unused
 			count: 1
 			path: src/Concerns/Commenter.php
-
-		-
-			message: '#^Property Illuminate\\Database\\Eloquent\\Model\:\:\$table \(string\|null\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Models/Message.php

--- a/src/Concerns/Commenter.php
+++ b/src/Concerns/Commenter.php
@@ -84,7 +84,7 @@ trait Commenter
             throw new DeleteCommentNotAllowedException();
         }
 
-        return $comment->delete();
+        return $comment->forceDelete();
     }
 
     /**

--- a/src/Models/CommentRevision.php
+++ b/src/Models/CommentRevision.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\Commentable\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+final class CommentRevision extends Model
+{
+    protected $guarded = [];
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->table = $this->revisionTable();
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * @return BelongsTo<Message, $this>
+     */
+    public function comment(): BelongsTo
+    {
+        return $this->belongsTo($this->configuredCommentModel(), 'comment_id', 'id');
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function editor(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return class-string<Message>
+     */
+    private function configuredCommentModel(): string
+    {
+        $model = config('commentable.models.comment', Comment::class);
+
+        if (is_string($model) && is_a($model, Message::class, true)) {
+            return $model;
+        }
+
+        return Comment::class;
+    }
+
+    /**
+     * @phpstan-return string
+     */
+    private function revisionTable(): string
+    {
+        $table = config('commentable.revision_table', 'comment_revisions');
+
+        return is_string($table) ? $table : 'comment_revisions';
+    }
+}

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -8,9 +8,21 @@ use Akira\Commentable\Contracts\CommentContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
 
+/**
+ * @property string $content
+ */
 abstract class Message extends Model implements CommentContract
 {
+    use SoftDeletes {
+        bootSoftDeletes as bootEloquentSoftDeletes;
+        performDeleteOnModel as performSoftDeleteOnModel;
+        restore as restoreSoftDeletedModel;
+    }
+
     protected $fillable = [
         'content',
         'commenter_type',
@@ -23,9 +35,19 @@ abstract class Message extends Model implements CommentContract
      */
     public function __construct(array $attributes = [])
     {
-        $this->table = config('commentable.comment_table', 'comments');
+        $this->table = self::commentTable();
 
         parent::__construct($attributes);
+    }
+
+    /**
+     * @phpstan-return void
+     */
+    final public static function bootSoftDeletes(): void
+    {
+        if (self::supportsSoftDeleteColumn()) {
+            static::bootEloquentSoftDeletes();
+        }
     }
 
     /**
@@ -51,6 +73,45 @@ abstract class Message extends Model implements CommentContract
     final public function replies(): HasMany
     {
         return $this->hasMany(Reply::class, 'reply_id', 'id');
+    }
+
+    /**
+     * @return HasMany<CommentRevision, $this>
+     */
+    final public function revisions(): HasMany
+    {
+        return $this->hasMany(CommentRevision::class, 'comment_id', 'id');
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    final public function edit(string $content, ?Model $editor = null, ?string $reason = null): bool
+    {
+        return (bool) $this->getConnection()->transaction(function () use ($content, $editor, $reason): bool {
+            $previousContent = $this->content;
+            $saved = $this->forceFill(['content' => $content])->save();
+
+            if (! $saved) {
+                return false;
+            }
+
+            $this->revisions()->create($this->prepareRevisionData($previousContent, $content, $editor, $reason));
+
+            return true;
+        });
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    final public function restore(): bool
+    {
+        if (! $this->supportsSoftDeletes()) {
+            return false;
+        }
+
+        return (bool) $this->restoreSoftDeletedModel();
     }
 
     /**
@@ -82,6 +143,20 @@ abstract class Message extends Model implements CommentContract
     }
 
     /**
+     * @phpstan-return mixed
+     */
+    protected function performDeleteOnModel(): mixed
+    {
+        if ($this->supportsSoftDeletes()) {
+            return $this->performSoftDeleteOnModel();
+        }
+
+        parent::performDeleteOnModel();
+
+        return null;
+    }
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array
@@ -89,8 +164,58 @@ abstract class Message extends Model implements CommentContract
 
         return [
             'approved' => 'boolean',
+            'deleted_at' => 'datetime',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    private static function supportsSoftDeleteColumn(): bool
+    {
+        try {
+            return Schema::hasColumn(self::commentTable(), 'deleted_at');
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @phpstan-return string
+     */
+    private static function commentTable(): string
+    {
+        $table = config('commentable.comment_table', 'comments');
+
+        return is_string($table) ? $table : 'comments';
+    }
+
+    /**
+     * @phpstan-return bool
+     */
+    private function supportsSoftDeletes(): bool
+    {
+        return self::supportsSoftDeleteColumn();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function prepareRevisionData(string $previousContent, string $newContent, ?Model $editor, ?string $reason): array
+    {
+        $revisionData = [
+            'previous_content' => $previousContent,
+            'new_content' => $newContent,
+            'reason' => $reason,
+        ];
+
+        if ($editor instanceof Model) {
+            $revisionData['editor_type'] = $editor::class;
+            $revisionData['editor_id'] = $editor->getKey();
+        }
+
+        return $revisionData;
     }
 }

--- a/tests/Fixtures/Feature/MessageAuditTest.php
+++ b/tests/Fixtures/Feature/MessageAuditTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Commentable\Models\Comment;
+use Akira\Commentable\Models\CommentRevision;
+use Akira\Commentable\Tests\Fixtures\ModeratorUser;
+use Akira\Commentable\Tests\Fixtures\Post;
+
+beforeEach(function (): void {
+    $this->user = user();
+    $this->post = Post::query()->create(['name' => 'post1', 'user_id' => $this->user->id]);
+});
+
+it('soft deletes and restores comments', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+
+    $this->user->deleteComment($comment);
+
+    $trashedComment = Comment::withTrashed()->find($comment->id);
+
+    expect(Comment::query()->find($comment->id))->toBeNull()
+        ->and($trashedComment)->toBeInstanceOf(Comment::class)
+        ->and($trashedComment->trashed())->toBeTrue()
+        ->and($trashedComment->restore())->toBeTrue()
+        ->and(Comment::query()->find($comment->id))->toBeInstanceOf(Comment::class);
+});
+
+it('force deletes comments permanently', function (): void {
+    $comment = user()->comment($this->post, 'comment1');
+    $moderator = ModeratorUser::query()->create([
+        'name' => 'moderator',
+        'email' => 'moderator@example.com',
+    ]);
+
+    $moderator->forceDeleteComment($comment);
+
+    expect(Comment::withTrashed()->find($comment->id))->toBeNull();
+});
+
+it('records comment edit revisions with editor metadata', function (): void {
+    $editor = user();
+    $comment = $this->user->comment($this->post, 'original');
+
+    $comment->edit('edited', $editor, 'clarified wording');
+
+    $revision = $comment->revisions()->first();
+
+    expect($comment->fresh()->content)->toBe('edited')
+        ->and($revision)->toBeInstanceOf(CommentRevision::class)
+        ->and($revision->previous_content)->toBe('original')
+        ->and($revision->new_content)->toBe('edited')
+        ->and($revision->reason)->toBe('clarified wording')
+        ->and($revision->editor)->toBeInstanceOf($editor::class)
+        ->and($revision->editor->getKey())->toBe($editor->getKey());
+});
+
+it('records reply edit revisions', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+    $reply = $this->user->reply($comment, 'original reply');
+
+    $reply->edit('edited reply');
+
+    expect($reply->fresh()->content)->toBe('edited reply')
+        ->and($reply->revisions)->toHaveCount(1)
+        ->first()
+        ->previous_content->toBe('original reply');
+});


### PR DESCRIPTION
Problem: #17 asks for recoverable deletes and edit revision history for moderation audit workflows.

Root cause: Comments deleted directly and content edits had no package-level audit trail.

Solution: Added soft delete support when the configured comments table has deleted_at, hard delete through forceDeleteComment, a CommentRevision model and revision table, Message::edit(), revisions(), restore(), migration guidance, schema docs, and tests for recovery, hard delete, and revision metadata.

Validation: composer test

Risk/rollback: Medium. Fresh installs get deleted_at and comment_revisions. Existing installs keep hard delete behavior until they add deleted_at and the revision table from the upgrade notes.

Fixes #17