### PR TITLE
feat(package): add compound query indexes (#19)

### DIFF
--- a/database/migrations/create_commentable_table.php
+++ b/database/migrations/create_commentable_table.php
@@ -26,6 +26,8 @@ return new class extends Migration
 
             $table->timestamps();
             $table->softDeletes();
+            $table->index(['commentable_type', 'commentable_id', 'approved', 'created_at'], 'commentable_approved_created_index');
+            $table->index(['reply_id', 'approved', 'created_at'], 'comments_reply_approved_created_index');
         });
 
         Schema::create($revisionTable, function (Blueprint $table) use ($commentTable): void {
@@ -44,6 +46,7 @@ return new class extends Migration
             $table->foreignId('comment_id')->constrained($commentTable)->cascadeOnDelete();
             $table->string('type');
             $table->timestamps();
+            $table->index(['comment_id', 'type'], 'reactions_comment_type_index');
         });
     }
 

--- a/docs/06-database-schema.md
+++ b/docs/06-database-schema.md
@@ -31,6 +31,8 @@ Stores all comments and replies in a single table using a self-referencing struc
 - Composite index on `commenter_type` and `commenter_id` (polymorphic)
 - Index on `reply_id`
 - Index on `approved`
+- Composite index `commentable_approved_created_index` on `commentable_type`, `commentable_id`, `approved`, and `created_at`
+- Composite index `comments_reply_approved_created_index` on `reply_id`, `approved`, and `created_at`
 
 #### Foreign Keys
 
@@ -119,6 +121,7 @@ Stores reactions (likes, loves, etc.) to comments and replies.
 - Primary key on `id`
 - Composite index on `owner_type` and `owner_id` (polymorphic)
 - Foreign key index on `comment_id`
+- Composite index `reactions_comment_type_index` on `comment_id` and `type`
 
 #### Foreign Keys
 
@@ -319,6 +322,21 @@ $post = Post::with([
     'comments.replies.commenter',
     'comments.reactions'
 ])->find(1);
+```
+
+## Upgrade Notes
+
+Existing installations can add the query indexes with a project migration:
+
+```php
+Schema::table(config('commentable.comment_table', 'comments'), function (Blueprint $table): void {
+    $table->index(['commentable_type', 'commentable_id', 'approved', 'created_at'], 'commentable_approved_created_index');
+    $table->index(['reply_id', 'approved', 'created_at'], 'comments_reply_approved_created_index');
+});
+
+Schema::table(config('commentable.reaction_table', 'reactions'), function (Blueprint $table): void {
+    $table->index(['comment_id', 'type'], 'reactions_comment_type_index');
+});
 ```
 
 **Previous:** [API Reference](05-api-reference.md) | **Next:** [Testing](07-testing.md)

--- a/tests/Fixtures/Feature/SchemaIndexTest.php
+++ b/tests/Fixtures/Feature/SchemaIndexTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+it('creates compound indexes for common comment queries', function (): void {
+    $commentIndexes = sqliteIndexNames('comments');
+    $reactionIndexes = sqliteIndexNames('reactions');
+
+    expect($commentIndexes)
+        ->toContain('commentable_approved_created_index')
+        ->toContain('comments_reply_approved_created_index')
+        ->and($reactionIndexes)
+        ->toContain('reactions_comment_type_index');
+});
+
+it('orders compound index columns for pagination and counts', function (): void {
+    expect(sqliteIndexColumns('commentable_approved_created_index'))
+        ->toBe(['commentable_type', 'commentable_id', 'approved', 'created_at'])
+        ->and(sqliteIndexColumns('comments_reply_approved_created_index'))
+        ->toBe(['reply_id', 'approved', 'created_at'])
+        ->and(sqliteIndexColumns('reactions_comment_type_index'))
+        ->toBe(['comment_id', 'type']);
+});
+
+/**
+ * @return list<string>
+ */
+function sqliteIndexNames(string $table): array
+{
+    return collect(DB::select("pragma index_list('{$table}')"))
+        ->pluck('name')
+        ->values()
+        ->all();
+}
+
+/**
+ * @return list<string>
+ */
+function sqliteIndexColumns(string $index): array
+{
+    return collect(DB::select("pragma index_info('{$index}')"))
+        ->pluck('name')
+        ->values()
+        ->all();
+}


### PR DESCRIPTION
Problem:
Issue #19 asks the package schema to support common comment, reply, and reaction queries without requiring consumers to add custom indexes immediately.

Root cause:
The migration only created basic indexes for polymorphic columns, `reply_id`, and `approved`. Common queries combine target model, approval state, parent reply, creation order, and reaction type.

Solution:
- Add a compound index for approved comment pagination by commentable target and creation date.
- Add a compound index for approved replies by parent and creation date.
- Add a compound index for reaction counts by comment and type.
- Document the new indexes and an upgrade migration for existing installations.
- Add SQLite schema assertions for index names and column order.

Validation:
- `vendor/bin/pest --compact tests/Fixtures/Feature/SchemaIndexTest.php`
- `composer test`

Risk/rollback:
Low. Fresh installs receive additional indexes. Existing installs can opt in with the documented migration. Rollback is dropping the three named indexes.

Fixes #19
