### PR TITLE
feat(package): add thread query scopes (#20)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "test:refactor": "rector --dry-run",
         "test:types": "phpstan",
         "test:type-coverage": "pest --type-coverage --min=100 --compact",
-        "test:coverage": "pest --parallel --coverage --compact --exactly=86.2",
+        "test:coverage": "pest --parallel --coverage --compact --exactly=86.4",
         "test:typos": "peck",
         "test": [
             "@test:lint",

--- a/docs/03-advanced-features.md
+++ b/docs/03-advanced-features.md
@@ -73,7 +73,11 @@ echo $comment->approved; // false
 ### Querying Approved Comments
 
 ```php
-$approvedComments = $post->comments()->approved()->get();
+$approvedComments = $post->comments()
+    ->approved()
+    ->withCommenter()
+    ->withReactionCounts()
+    ->get();
 
 $pendingComments = $post->comments()->pending()->get();
 ```
@@ -119,6 +123,17 @@ $pending = Comment::pending()
     ->with(['commenter', 'commentable'])
     ->orderBy('created_at', 'desc')
     ->paginate(20);
+```
+
+### Loading Threads
+
+Use `commentsWithThread()` to load comments, commenters, replies, nested reply commenters, and reaction counts for a commentable model:
+
+```php
+$comments = $post->commentsWithThread()
+    ->approved()
+    ->latest()
+    ->get();
 ```
 
 ## Soft Deletes and Recovery

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -26,7 +26,25 @@ public function comments(): MorphMany
 ```php
 $post = Post::find(1);
 $comments = $post->comments; // All comments on this post
-$approvedComments = $post->comments()->where('approved', true)->get();
+$approvedComments = $post->comments()->approved()->get();
+```
+
+---
+
+##### `commentsWithThread(): MorphMany`
+
+Returns comments with commenters, replies, nested reply commenters, and reaction counts eager loaded.
+
+```php
+public function commentsWithThread(): MorphMany
+```
+
+**Returns:** `MorphMany<Comment>` - Comment query with thread relationships
+
+**Example:**
+```php
+$post = Post::find(1);
+$comments = $post->commentsWithThread()->approved()->get();
 ```
 
 ---
@@ -531,6 +549,66 @@ final public function scopePending(Builder $query): Builder
 **Example:**
 ```php
 $pendingComments = Comment::pending()->get();
+```
+
+---
+
+##### `withCommenter(Builder $query): Builder`
+
+Eager loads the commenter relationship.
+
+```php
+final public function scopeWithCommenter(Builder $query): Builder
+```
+
+**Example:**
+```php
+$comments = Comment::withCommenter()->get();
+```
+
+---
+
+##### `withReplies(Builder $query): Builder`
+
+Eager loads direct replies.
+
+```php
+final public function scopeWithReplies(Builder $query): Builder
+```
+
+**Example:**
+```php
+$comments = Comment::withReplies()->get();
+```
+
+---
+
+##### `withThread(Builder $query): Builder`
+
+Eager loads commenters, direct replies, nested reply commenters, and reaction owners.
+
+```php
+final public function scopeWithThread(Builder $query): Builder
+```
+
+**Example:**
+```php
+$comments = Comment::withThread()->get();
+```
+
+---
+
+##### `withReactionCounts(Builder $query): Builder`
+
+Eager loads the `reactions_count` aggregate without loading reaction rows.
+
+```php
+final public function scopeWithReactionCounts(Builder $query): Builder
+```
+
+**Example:**
+```php
+$comments = Comment::withReactionCounts()->get();
 ```
 
 ---

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -143,7 +143,8 @@ Add pagination for large comment threads:
 
 ```php
 $comments = $post->comments()
-    ->where('approved', true)
+    ->approved()
+    ->withReactionCounts()
     ->latest()
     ->paginate(20);
 ```
@@ -156,22 +157,13 @@ $comments = $post->comments()
 Accessing reactions or replies causes many queries.
 
 **Solution:**
-Create query scopes for common loading patterns:
+Use the package thread-loading scopes:
 
 ```php
-// In Comment model
-public function scopeWithFullThread($query)
-{
-    return $query->with([
-        'commenter',
-        'replies.commenter',
-        'replies.replies.commenter',
-        'reactions.owner'
-    ]);
-}
-
-// Usage
-$comments = $post->comments()->withFullThread()->get();
+$comments = $post->commentsWithThread()
+    ->approved()
+    ->latest()
+    ->get();
 ```
 
 ---

--- a/src/Concerns/Commentable.php
+++ b/src/Concerns/Commentable.php
@@ -4,15 +4,24 @@ declare(strict_types=1);
 
 namespace Akira\Commentable\Concerns;
 
+use Akira\Commentable\Models\Message;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait Commentable
 {
     /**
-     * Get the comments for the model.
+     * @return MorphMany<Message, Commentable>
      */
     public function comments(): MorphMany
     {
         return $this->morphMany(config('commentable.models.comment'), 'commentable');
+    }
+
+    /**
+     * @return MorphMany<Message, Commentable>
+     */
+    public function commentsWithThread(): MorphMany
+    {
+        return $this->comments()->withThread()->withReactionCounts();
     }
 }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -154,6 +154,47 @@ abstract class Message extends Model implements CommentContract
     }
 
     /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    final public function scopeWithCommenter(Builder $query): Builder
+    {
+        return $query->with('commenter');
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    final public function scopeWithReplies(Builder $query): Builder
+    {
+        return $query->with('replies');
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    final public function scopeWithThread(Builder $query): Builder
+    {
+        return $query->with([
+            'commenter',
+            'replies.commenter',
+            'replies.replies.commenter',
+            'reactions.owner',
+        ]);
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    final public function scopeWithReactionCounts(Builder $query): Builder
+    {
+        return $query->withCount('reactions');
+    }
+
+    /**
      * @return class-string<Message>
      */
     final protected static function configuredCommentModel(): string

--- a/tests/Fixtures/Feature/MessageQueryScopeTest.php
+++ b/tests/Fixtures/Feature/MessageQueryScopeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\Commentable\Models\Comment;
+use Akira\Commentable\Models\Reaction;
+use Akira\Commentable\Tests\Fixtures\Post;
+
+beforeEach(function (): void {
+    $this->user = user();
+    $this->post = Post::query()->create([
+        'name' => 'post1',
+        'user_id' => $this->user->id,
+    ]);
+});
+
+it('loads approved comments with commenter and reaction counts', function (): void {
+    $approved = $this->user->comment($this->post, 'approved');
+    $pending = $this->user->comment($this->post, 'pending');
+
+    $approved->approve();
+    Reaction::query()->create([
+        'comment_id' => $approved->id,
+        'owner_type' => $this->user::class,
+        'owner_id' => $this->user->id,
+        'type' => 'like',
+    ]);
+
+    $comments = Comment::query()
+        ->approved()
+        ->withCommenter()
+        ->withReactionCounts()
+        ->get();
+
+    expect($comments)->toHaveCount(1)
+        ->first()
+        ->content->toBe('approved')
+        ->and($comments->first()->relationLoaded('commenter'))->toBeTrue()
+        ->and($comments->first()->relationLoaded('reactions'))->toBeFalse()
+        ->and($comments->first()->reactions_count)->toBe(1)
+        ->and(Comment::query()->pending()->pluck('id')->all())->toBe([$pending->id]);
+});
+
+it('loads nested thread relationships through the commentable helper', function (): void {
+    $comment = $this->user->comment($this->post, 'comment1');
+    $reply = $this->user->reply($comment, 'reply1');
+    $nestedReply = $this->user->reply($reply, 'reply2');
+
+    Reaction::query()->create([
+        'comment_id' => $comment->id,
+        'owner_type' => $this->user::class,
+        'owner_id' => $this->user->id,
+        'type' => 'like',
+    ]);
+
+    $threadComment = $this->post->commentsWithThread()->first();
+    $threadReply = $threadComment->replies->first();
+
+    expect($threadComment->is($comment))->toBeTrue()
+        ->and($threadComment->relationLoaded('commenter'))->toBeTrue()
+        ->and($threadComment->relationLoaded('replies'))->toBeTrue()
+        ->and($threadComment->reactions_count)->toBe(1)
+        ->and($threadReply->is($reply))->toBeTrue()
+        ->and($threadReply->relationLoaded('commenter'))->toBeTrue()
+        ->and($threadReply->relationLoaded('replies'))->toBeTrue()
+        ->and($threadReply->replies->first()->is($nestedReply))->toBeTrue();
+});


### PR DESCRIPTION
Problem:
Issue #20 asks for package-level query helpers for common comment views so consumers do not need ad hoc eager-loading patterns.

Root cause:
Relationships existed, but the package did not expose scopes above raw Eloquent `with()` and `where()` calls for thread loading, commenters, replies, and reaction counts.

Solution:
- Add `commentsWithThread()` to the `Commentable` trait.
- Add `withCommenter`, `withReplies`, `withThread`, and `withReactionCounts` scopes to `Message`.
- Update docs to use package scopes instead of app-local query snippets.
- Add tests for approved loading, commenter eager loading, reaction counts, and nested thread loading.

Validation:
- `vendor/bin/pest --compact tests/Fixtures/Feature/MessageQueryScopeTest.php`
- `composer test`

Risk/rollback:
Low. The scopes only compose existing Eloquent relationships and aggregates. Rollback is removing the helper, scopes, docs, and tests.

Fixes #20
